### PR TITLE
Potential fix for code scanning alert no. 6: Missing rate limiting

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,12 @@
     "lint": "eslint src/**/*.js",
     "lint:fix": "eslint src/**/*.js --fix"
   },
-  "keywords": ["expense", "management", "api", "odoo"],
+  "keywords": [
+    "expense",
+    "management",
+    "api",
+    "odoo"
+  ],
   "author": "",
   "license": "ISC",
   "type": "commonjs",
@@ -27,7 +32,8 @@
     "cors": "^2.8.5",
     "helmet": "^7.1.0",
     "morgan": "^1.10.0",
-    "dotenv": "^16.3.1"
+    "dotenv": "^16.3.1",
+    "express-rate-limit": "^8.1.0"
   },
   "devDependencies": {
     "nodemon": "^3.0.2",

--- a/backend/src/routes/expenses.js
+++ b/backend/src/routes/expenses.js
@@ -2,9 +2,17 @@ const express = require('express');
 const router = express.Router();
 const expenseController = require('../controllers/expenseController');
 const auth = require('../middleware/auth');
+const rateLimit = require('express-rate-limit');
 
 // All expense routes require authentication
 router.use(auth);
+
+// Apply rate limiter to all expense routes
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
+router.use(limiter);
 
 // GET /api/expenses
 router.get('/', expenseController.getExpenses);


### PR DESCRIPTION
Potential fix for [https://github.com/KunjShah01/odoo-hackathon/security/code-scanning/6](https://github.com/KunjShah01/odoo-hackathon/security/code-scanning/6)

To resolve the missing rate limiting vulnerability in this file, we should add a rate limiting middleware to the expense routes. The recommended library for Express apps is `express-rate-limit`. We will:
- Import `express-rate-limit` near the top of the file.
- Define a rate limiter instance (e.g., limit each user/IP to a reasonable number of requests per window, such as 100 requests per 15 minutes).
- Apply the rate limiter to the router at a global level, ideally before the expense routes are registered, right after the authentication middleware.
- No changes to existing route handlers are needed.

We will make these edits directly in backend/src/routes/expenses.js:
- Add the `express-rate-limit` import.
- Add definition of the rate limiter (e.g., `const rateLimit = require('express-rate-limit'); ...`).
- Insert router-wide usage of the rate limiter with `router.use(limiter);` after the authentication middleware.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
