### PR TITLE
Potential fix for code scanning alert no. 1: Clear text storage of sensitive information

### DIFF
--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -43,9 +43,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    const storedUser = localStorage.getItem('user');
-    if (storedUser) {
-      setUser(JSON.parse(storedUser));
+    const storedUserId = localStorage.getItem('userId');
+    if (storedUserId) {
+      const foundUser = MOCK_USERS.find(u => u.id === storedUserId);
+      if (foundUser) {
+        setUser(foundUser);
+      }
     }
     setIsLoading(false);
   }, []);
@@ -57,7 +60,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const foundUser = MOCK_USERS.find(u => u.email === email && u.role === role);
     if (foundUser) {
       setUser(foundUser);
-      localStorage.setItem('user', JSON.stringify(foundUser));
+      localStorage.setItem('userId', foundUser.id);
     } else {
       throw new Error('Invalid credentials');
     }
@@ -83,13 +86,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     };
 
     setUser(newUser);
-    localStorage.setItem('user', JSON.stringify(newUser));
+    localStorage.setItem('userId', newUser.id);
     setIsLoading(false);
   };
 
   const logout = () => {
     setUser(null);
-    localStorage.removeItem('user');
+    localStorage.removeItem('userId');
   };
 
   return (


### PR DESCRIPTION
Potential fix for [https://github.com/KunjShah01/odoo-hackathon/security/code-scanning/1](https://github.com/KunjShah01/odoo-hackathon/security/code-scanning/1)

To address the problem, we should avoid storing sensitive or user-controlled information in clear text in localStorage. The best approach is to store either a non-sensitive session identifier or, for small toy apps, to at least avoid storing user fields that could be abused (such as `role`). In this case, since there is no session backend and everything is mocked, the most meaningful adjustment is to minimize what is saved and to avoid storing user data that comes directly from untrusted form fields. As a secure demonstration, we could store only a safe identifier (e.g., user ID) or just the role if needed for functionality, but ideally not even those.

**Best practice in real apps:** store only non-sensitive tokens (e.g., a secure random string or opaque session ID) and fetch actual user data from a trusted backend, not from browser localStorage.

**In this code:**  
- Change lines saving the full user object (`localStorage.setItem('user', JSON.stringify(newUser))`) to store only a minimal, non-sensitive subset (e.g., `id`) or avoid localStorage altogether if possible.
- Explicitly **do not store any field that comes directly from user input unless it's been validated and is strictly needed**.
- In this mockup, perhaps store just the user ID; upon reload, find the user in `MOCK_USERS` by ID.

**Required changes:**  
- Change `localStorage.setItem('user', JSON.stringify(newUser));` to `localStorage.setItem('userId', newUser.id);` and similarly on login.
- Change the effect that loads from storage (`useEffect`) to fetch the corresponding user from `MOCK_USERS` by stored ID.
- Remove storage and reading of other user information from localStorage.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
